### PR TITLE
fixed the padding overflow error

### DIFF
--- a/lib/pages/exhibitor/upload_pamphlet.dart
+++ b/lib/pages/exhibitor/upload_pamphlet.dart
@@ -30,141 +30,149 @@ class _UploadPamphletPageState extends State<UploadPamphletPage> {
 
   @override
   Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    double paddingValue = screenWidth * 0.15;
     return Scaffold(
-        appBar: AppBar(
-          leading: const BackButton(),
-          title: const Text("Upload Pamphlet"),
-        ),
-        body: Container(
-            padding: const EdgeInsets.all(150),
-            child: Form(
-                key: _formKey, // Set the key to the form
-                child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      TextFormField(
-                        controller: eventCodeInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Event Name',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter the event code';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextFormField(
-                        controller: boothNumberInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Booth Number',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter the booth number';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextFormField(
-                        controller: orgNameInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Organization Name',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter the organization name';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextFormField(
-                        controller: yourNameInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Your Name',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter your name';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextFormField(
-                        controller: emailAddressInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Email Address',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter the email address';
-                          }
-                          return null;
-                        },
-                      ),
-                      TextField(
-                        controller: phoneNumberInput,
-                        autofocus: false,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Phone Number',
-                        ),
-                      ),
-                      TextFormField(
-                        readOnly: true,
-                        controller: pamphletInput,
-                        onTap: () async {
-                          FilePickerResult? result =
-                              await FilePicker.platform.pickFiles(
-                            type: FileType.custom,
-                            allowedExtensions: ['pdf'],
-                          );
-                          if (result != null) {
-                            String filePath = result.files.single.path!;
-                            // Do something with the file path (store it or display the file name, etc.)
-                            pamphletInput.text =
-                                filePath.substring(filePath.lastIndexOf("/")+1);
-                            if (kDebugMode) {
-                              print('Selected file: $filePath');
-                            }
-                          }
-                        },
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          labelText: 'Upload Pamphlet',
-                        ),
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please upload the pamphlet';
-                          }
-                          return null;
-                        },
-                      ),
-                      ElevatedButton(
-                        onPressed: () {
-                          if (_formKey.currentState!.validate()) {
-                            moveToPage(context, const ConfirmationPage());
-                          }
-                        },
-                        child: const Text('Confirm'),
-                      ),
-                    ]))));
+      appBar: AppBar(
+        leading: const BackButton(),
+        title: const Text("Upload Pamphlet"),
+      ),
+      body: SingleChildScrollView(
+        child: Container(
+          padding: EdgeInsets.all(paddingValue),
+          child: Form(
+            key: _formKey, // Set the key to the form
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                TextFormField(
+                  controller: eventCodeInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Event Name',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter the event code';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: boothNumberInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Booth Number',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter the booth number';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: orgNameInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Organization Name',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter the organization name';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: yourNameInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Your Name',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter your name';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: emailAddressInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Email Address',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter the email address';
+                    }
+                    return null;
+                  },
+                ),
+                TextField(
+                  controller: phoneNumberInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Phone Number',
+                  ),
+                ),
+                TextFormField(
+                  readOnly: true,
+                  controller: pamphletInput,
+                  onTap: () async {
+                    FilePickerResult? result =
+                        await FilePicker.platform.pickFiles(
+                      type: FileType.custom,
+                      allowedExtensions: ['pdf'],
+                    );
+                    if (result != null) {
+                      String filePath = result.files.single.path!;
+                      // Do something with the file path (store it or display the file name, etc.)
+                      pamphletInput.text =
+                          filePath.substring(filePath.lastIndexOf("/")+1);
+                      if (kDebugMode) {
+                        print('Selected file: $filePath');
+                      }
+                    }
+                  },
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Upload Pamphlet',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please upload the pamphlet';
+                    }
+                    return null;
+                  },
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      moveToPage(context, const ConfirmationPage());
+                    }
+                  },
+                  child: const Text('Confirm'),
+                ),
+              ]
+            )
+          )
+        )
+      )
+    );
   }
 }

--- a/lib/pages/organizer/create_new_event.dart
+++ b/lib/pages/organizer/create_new_event.dart
@@ -31,133 +31,137 @@ class _CreateNewEventPageState extends State<CreateNewEventPage> {
  
   @override
   Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    double paddingValue = screenWidth * 0.15;
     return Scaffold(
       appBar: AppBar(
         leading: const BackButton(),
         title: const Text("Create New Event"),
       ),
-      body: Container(
-        padding: const EdgeInsets.all(250),
-        child: Form(
-          key: _formKey, // Set the key to the form
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              TextFormField(
-                controller: eventNameInput,
-                autofocus: false,
-                textInputAction: TextInputAction.next,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Event Name',
-                ),
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter an event name';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                controller: startDateInput,
-                decoration: const InputDecoration(
-                  icon: Icon(Icons.calendar_today),
-                  labelText: "Start Date",
-                ),
-                readOnly: true,
-                onTap: () async {
-                  DateTime? pickedDate = await showDatePicker(
-                    context: context,
-                    initialDate: DateTime.now(),
-                    firstDate: DateTime(1950),
-                    lastDate: DateTime(2100),
-                  );
-
-                  if (pickedDate != null) {
-                    String formattedDate =
-                        DateFormat('yyyy-MM-dd').format(pickedDate);
-
-                    if (endDateInput.text.isNotEmpty &&
-                        pickedDate.isAfter(
-                            DateTime.parse(endDateInput.text))) {
-                      // Selected start date is after the end date
-                      // Show error message
-                      if (!mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text("Start date should be before end date!"),
-                        ),
-                      );
-                    } else {
-                      setState(() {
-                        startDateInput.text = formattedDate;
-                      });
+      body: SingleChildScrollView(
+        child: Container(
+          padding: EdgeInsets.all(paddingValue), 
+          child: Form(
+            key: _formKey, // Set the key to the form
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                TextFormField(
+                  controller: eventNameInput,
+                  autofocus: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Event Name',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter an event name';
                     }
-                  }
-                },
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please select a start date';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                controller: endDateInput,
-                decoration: const InputDecoration(
-                  icon: Icon(Icons.calendar_today),
-                  labelText: "End Date",
+                    return null;
+                  },
                 ),
-                readOnly: true,
-                onTap: () async {
-                  DateTime? pickedDate = await showDatePicker(
-                    context: context,
-                    initialDate: DateTime.now(),
-                    firstDate: DateTime(1950),
-                    lastDate: DateTime(2100),
-                  );
-                  if (pickedDate != null) {
-                    String formattedDate =
-                        DateFormat('yyyy-MM-dd').format(pickedDate);
+                TextFormField(
+                  controller: startDateInput,
+                  decoration: const InputDecoration(
+                    icon: Icon(Icons.calendar_today),
+                    labelText: "Start Date",
+                  ),
+                  readOnly: true,
+                  onTap: () async {
+                    DateTime? pickedDate = await showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(1950),
+                      lastDate: DateTime(2100),
+                    );
 
-                    if (startDateInput.text.isNotEmpty &&
-                        pickedDate.isBefore(
-                            DateTime.parse(startDateInput.text))) {
-                      // Selected end date is before the start date
-                      // Show error message
-                      if (!mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text("End date should be after start date!"),
-                        ),
-                      );
-                    } else {
-                      setState(() {
-                        endDateInput.text = formattedDate;
-                      });
+                    if (pickedDate != null) {
+                      String formattedDate =
+                          DateFormat('yyyy-MM-dd').format(pickedDate);
+
+                      if (endDateInput.text.isNotEmpty &&
+                          pickedDate.isAfter(
+                              DateTime.parse(endDateInput.text))) {
+                        // Selected start date is after the end date
+                        // Show error message
+                        if (!mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text("Start date should be before end date!"),
+                          ),
+                        );
+                      } else {
+                        setState(() {
+                          startDateInput.text = formattedDate;
+                        });
+                      }
                     }
-                  }
-                },
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please select an end date';
-                  }
-                  return null;
-                },
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  if (_formKey.currentState!.validate()) {
-                    generateAndShowEventCode(context);
-                  }
-                },
-                child: const Text('Submit Event and Create Event Code'),
-              )
-            ]
+                  },
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please select a start date';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: endDateInput,
+                  decoration: const InputDecoration(
+                    icon: Icon(Icons.calendar_today),
+                    labelText: "End Date",
+                  ),
+                  readOnly: true,
+                  onTap: () async {
+                    DateTime? pickedDate = await showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(1950),
+                      lastDate: DateTime(2100),
+                    );
+                    if (pickedDate != null) {
+                      String formattedDate =
+                          DateFormat('yyyy-MM-dd').format(pickedDate);
+
+                      if (startDateInput.text.isNotEmpty &&
+                          pickedDate.isBefore(
+                              DateTime.parse(startDateInput.text))) {
+                        // Selected end date is before the start date
+                        // Show error message
+                        if (!mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text("End date should be after start date!"),
+                          ),
+                        );
+                      } else {
+                        setState(() {
+                          endDateInput.text = formattedDate;
+                        });
+                      }
+                    }
+                  },
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please select an end date';
+                    }
+                    return null;
+                  },
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      generateAndShowEventCode(context);
+                    }
+                  },
+                  child: const Text('Submit Event'),
+                )
+              ]
+            )
           )
         )
-      )
+      ) 
     );
   }
 

--- a/lib/pages/organizer/inquiry.dart
+++ b/lib/pages/organizer/inquiry.dart
@@ -31,13 +31,15 @@ class _InquiryPageState extends State<InquiryPage> {
 
   @override
   Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    double paddingValue = screenWidth * 0.15;
     return Scaffold(
       appBar: AppBar(
         leading: const BackButton(),
         title: const Text('Inquiry'),
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 200),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(paddingValue),
         child: Form(
           key: _formKey,
           child: Column(
@@ -73,8 +75,9 @@ class _InquiryPageState extends State<InquiryPage> {
                 },
               ),
               ElevatedButton(
-                  onPressed: submitInquiryButtonPressed,
-                  child: const Text("Submit")),
+                onPressed: submitInquiryButtonPressed,
+                child: const Text("Submit")
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
Previously, users were not able to click/select some of the buttons/textboxes in smaller devices due to the overflow error. I made the three pages (create_new_event, upload_pamphlet, and inquiry) reactive by utilizing SingleChildScrollView class. The users can now scroll and view what they have entered while filling out the textboxes. 

So far, I only modified the above three pages since these pages require the users to enter some information, but I could modify other pages if needed. 