### PR TITLE
finish implementation of event-related features using Firebase

### DIFF
--- a/lib/cloud_functions/event.dart
+++ b/lib/cloud_functions/event.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+// fsGetEventName() async {
+//   final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+//   QuerySnapshot<Map<String, dynamic>> snapshot =
+//       await firestore.collection("registered_event").get();
+//   return snapshot.docs.map((e) => e.data()).toList();
+// }
+
+getEventNameByCode(String eventCode) async {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+  try {
+    // search document based on given eventcode
+    QuerySnapshot<Map<String, dynamic>> snapshot = await firestore
+        .collection("registered_events")
+        .where('eventCode', isEqualTo: eventCode)
+        .get();
+
+    if (snapshot.docs.isNotEmpty) {
+      var doc = snapshot.docs.first.data();
+      return {
+        'eventName': doc['eventName'] as String?,
+        'startDate': doc['startDate'] as String?,
+        'endDate': doc['endDate'] as String?
+      };
+    } else {
+      return null;
+    }
+  } catch (e) {
+    print('Error fetching event data: $e');
+    return null;
+  }
+}

--- a/lib/pages/organizer/create_new_event.dart
+++ b/lib/pages/organizer/create_new_event.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'package:flutter/services.dart';
 
 // import 'package:firebase_core/firebase_core.dart';
-// import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 // import 'package:test/cloud_functions/test_firestore.dart';
 
 class CreateNewEventPage extends StatefulWidget {
@@ -19,7 +19,8 @@ class _CreateNewEventPageState extends State<CreateNewEventPage> {
   TextEditingController endDateInput = TextEditingController();
   TextEditingController eventNameInput = TextEditingController();
   late String eventCode; // Variable to store the generated event code
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>(); // Add a form key
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance; // Add a form key
 
   @override
   void initState() {
@@ -150,9 +151,12 @@ class _CreateNewEventPageState extends State<CreateNewEventPage> {
                   },
                 ),
                 ElevatedButton(
-                  onPressed: () {
+                  onPressed: () async {
                     if (_formKey.currentState!.validate()) {
-                      generateAndShowEventCode(context);
+                      await saveEventData();
+                      if (mounted) {
+                        generateAndShowEventCode(context);
+                      }
                     }
                   },
                   child: const Text('Submit Event'),
@@ -163,6 +167,22 @@ class _CreateNewEventPageState extends State<CreateNewEventPage> {
         )
       ) 
     );
+  }
+
+  Future<void> saveEventData() async {
+    try {
+      // Firestoreにイベントデータを保存
+      await _firestore.collection("registered_events").add({
+        'eventName': eventNameInput.text,
+        'startDate': startDateInput.text,
+        'endDate': endDateInput.text,
+        'eventCode': eventCode,
+      });
+      // 保存後の処理（例：メッセージ表示、画面遷移など）をここに記述
+    } catch (e) {
+      // エラーハンドリング
+      print('Error saving event data: $e');
+    }
   }
 
   void generateAndShowEventCode(BuildContext context) {

--- a/lib/pages/organizer/inquiry.dart
+++ b/lib/pages/organizer/inquiry.dart
@@ -1,8 +1,8 @@
-//import 'package:firebase_core/firebase_core.dart';
+// import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:test/util/navigate.dart';
 
-// import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 // import 'package:test/cloud_functions/test_firestore.dart';
 
@@ -18,6 +18,7 @@ class _InquiryPageState extends State<InquiryPage> {
   final TextEditingController _messageInputController = TextEditingController();
   final GlobalKey<FormState> _formKey =
       GlobalKey<FormState>(); // Add a form key
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   // final FirebaseFirestore _firestore = FirebaseFirestore.instanceFor(app: Firebase.app("test-project"));
   // final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -85,7 +86,7 @@ class _InquiryPageState extends State<InquiryPage> {
     );
   }
 
-  submitInquiryButtonPressed() {
+  void submitInquiryButtonPressed() async {
     // TODO: send email to us
     // () async {
     //   await _firestore
@@ -95,22 +96,29 @@ class _InquiryPageState extends State<InquiryPage> {
     // };
 
     if (_formKey.currentState!.validate()) {
-      showDialog(
-        context: context,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            title: const Text('success'),
-            actions: [
-              TextButton(
-                onPressed: () {
-                  popToPage(context, "OrganizerHomePage");
-                },
-                child: const Text('OK'),
-              ),
-            ],
-          );
-        },
-      );
+      // Firestoreにデータを保存
+      await _firestore.collection("inquiry").add({
+        'email': _emailInputController.text,
+        'message': _messageInputController.text,
+      });
+      if (mounted) {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('success'),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    popToPage(context, "OrganizerHomePage");
+                  },
+                  child: const Text('OK'),
+                ),
+              ],
+            );
+          },
+        );
+      }
     }
   }
 }

--- a/lib/pages/visitor/events.dart
+++ b/lib/pages/visitor/events.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'dart:convert';
-// import 'dart:io';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:test/util/navigate.dart';
 import 'package:test/pages/visitor/event_view.dart';
 import 'package:test/pages/visitor/register_new_event.dart';
+import 'package:path_provider/path_provider.dart';
 
 class EventsPage extends StatefulWidget {
   const EventsPage({super.key});
@@ -18,14 +19,39 @@ class EventsPage extends StatefulWidget {
 class _EventsPageState extends State<EventsPage> {
   List _eventData = [];
 
+  // Future<void> readJson() async {
+  //   final String response =
+  //       // await rootBundle.loadString('assets/dummy_event.json');
+  //       await rootBundle.loadString('assets/save_registered_event_by_visitors.json');
+  //   final data = await json.decode(response);
+  //   setState(() {
+  //     _eventData = data["events"];
+  //   });
+  //   debugPrint(_eventData.toString());
+  // }
   Future<void> readJson() async {
-    final String response =
-        await rootBundle.loadString('assets/dummy_event.json');
-    final data = await json.decode(response);
-    setState(() {
-      _eventData = data["events"];
-    });
-    debugPrint(_eventData.toString());
+    try {
+      final directory = await getApplicationDocumentsDirectory();
+      final file = File('${directory.path}/save_registered_event_by_visitors.json');
+
+      // ファイルが存在するか確認
+      if (!await file.exists()) {
+        print("file not found");
+        return;
+      }
+
+      // ファイルからJSONを読み込む
+      String content = await file.readAsString();
+      final data = jsonDecode(content);
+
+      setState(() {
+        _eventData = data["events"] ?? [];
+      });
+
+      debugPrint(_eventData.toString());
+    } catch (e) {
+      print("error occurred: $e");
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
 
   firebase_core: ^2.24.2
   #database
-  cloud_firestore: ^4.13.6
+  cloud_firestore: ^4.14.0
   #user auth
   # firebase_auth:
   # google_sign_in:
@@ -45,10 +45,11 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class  for iOS style icons.
   cupertino_icons: ^1.0.2
-  firebase_auth: ^4.15.3
+  firebase_auth: ^4.16.0
   intl: ^0.19.0
   # file_picker: ^4.0.0
   file_picker: ^6.1.1
+  path_provider: ^2.1.2
 
 dev_dependencies:
   flutter_test:
@@ -73,7 +74,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
-
+    
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
1. Change organizers' "Create New Event Page" 
- save "event name", "event code", "start date" and "end date" to collection "registered events" in cloud firestore when "Submit Event" Botton is pressed

2. Change organizers' "Inquiry Page" 
- save "email" and "message" to collection "inquiry" in cloud firestore when "Submit" Botton is pressed
<img width="1277" alt="スクリーンショット 2024-01-13 21 24 46" src="https://github.com/minsuk00/Solution-Challenge-2024/assets/108507859/9d5f0f9b-bbef-4972-95bc-889ae29756cb">

3. Change visitors' "Event Page" and "Register New Event Page"
- When an event code in the 'inquiry' collection in Cloud Firestore is called, 
display registered events on "Event Page" and
save "event name", "start date", and "end date" to a local JSON file "save_registered_event_by_visitors.json" to use "Event View Page" (install path_provider)
<img width="558" alt="スクリーンショット 2024-01-13 21 42 45" src="https://github.com/minsuk00/Solution-Challenge-2024/assets/108507859/640ba3d3-738c-40f9-8a00-1cb6616bd2bc">

