### PR TITLE
finish implementation of pamphlet-related features

### DIFF
--- a/lib/cloud_functions/event.dart
+++ b/lib/cloud_functions/event.dart
@@ -1,14 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:path_provider/path_provider.dart';
+import 'dart:convert';
+import 'dart:io';
 
-// fsGetEventName() async {
-//   final FirebaseFirestore firestore = FirebaseFirestore.instance;
-
-//   QuerySnapshot<Map<String, dynamic>> snapshot =
-//       await firestore.collection("registered_event").get();
-//   return snapshot.docs.map((e) => e.data()).toList();
-// }
-
-getEventNameByCode(String eventCode) async {
+getEventInfo(String eventCode) async {
   final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
   try {
@@ -31,5 +26,27 @@ getEventNameByCode(String eventCode) async {
   } catch (e) {
     print('Error fetching event data: $e');
     return null;
+  }
+}
+
+class GetEventListFromLocalFile {
+  static Future<List> readJson() async {
+    List eventData = [];
+    try {
+      final directory = await getApplicationDocumentsDirectory();
+      final file = File('${directory.path}/registered_events_by_visitors.json');
+
+      if (!await file.exists()) {
+        print("file not found");
+        return eventData;
+      }
+
+      String content = await file.readAsString();
+      final data = jsonDecode(content);
+      eventData = data["events"] ?? [];
+    } catch (e) {
+      print("error occurred: $e");
+    }
+    return eventData;
   }
 }

--- a/lib/cloud_functions/pamphlets.dart
+++ b/lib/cloud_functions/pamphlets.dart
@@ -1,0 +1,93 @@
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+getPamphletPdf(String boothCode) async {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+  final FirebaseStorage storage = FirebaseStorage.instance;
+//   // String downloadUrl = await storage.ref('uploaded_pdfs/$fileId').getDownloadURL();
+  try {
+    // search document based on given eventcode
+    QuerySnapshot<Map<String, dynamic>> snapshot = await firestore
+        .collection("uploaded_pamphlets")
+        .where('boothCode', isEqualTo: boothCode)
+        .get();
+
+    if (snapshot.docs.isNotEmpty) {
+      var doc = snapshot.docs.first.data();
+      return {
+          'pamphletURL': doc['pamphletURL'] as String?,
+      };
+    } else {
+      return null;
+    }
+  } catch (e) {
+    print('Error fetching event data: $e');
+    return null;
+  }
+}
+
+getBoothInfo(String boothCode) async {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+  try {
+    // search document based on given eventcode
+    QuerySnapshot<Map<String, dynamic>> snapshot = await firestore
+        .collection("uploaded_pamphlets")
+        .where('boothCode', isEqualTo: boothCode)
+        .get();
+
+    if (snapshot.docs.isNotEmpty) {
+      var doc = snapshot.docs.first.data();
+      return {
+          'eventCode': doc['eventCode'] as String?,
+          'eventName': doc['eventName'] as String?,
+          'boothNumber': doc['boothNumber'] as String?,
+          'orgName': doc['orgName'] as String?,
+          'yourName': doc['yourName'] as String?,
+          'emailAddress': doc['emailAddressInput'] as String?,
+          'phoneNumber': doc['phoneNumber'] as String?,
+          'boothCode': doc['boothCode'] as String?,
+          // 'pamphletURL': doc['pamphletURL'] as String?,
+      };
+    } else {
+      return null;
+    }
+  } catch (e) {
+    print('Error fetching event data: $e');
+    return null;
+  }
+}
+
+getAllBoothInfoForAnEvent(String eventCode) async {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+  try {
+    // search document based on given eventcode
+    QuerySnapshot<Map<String, dynamic>> snapshot = await firestore
+        .collection("uploaded_pamphlets")
+        .where('eventCode', isEqualTo: eventCode)
+        .get();
+
+    if (snapshot.docs.isNotEmpty) {
+      // add all boot information to list
+      List<Map<String, dynamic>> boothsInfo = snapshot.docs.map((doc) => {
+        'eventCode': doc['eventCode'] as String?,
+        'eventName': doc['eventName'] as String?,
+        'boothNumber': doc['boothNumber'] as String?,
+        'orgName': doc['orgName'] as String?,
+        'yourName': doc['yourName'] as String?,
+        'emailAddress': doc['emailAddress'] as String?,
+        'phoneNumber': doc['phoneNumber'] as String?,
+        'boothCode': doc['boothCode'] as String?,
+        // 'pamphletURL': doc['pamphletURL'] as String?,
+      }).toList();
+
+      return boothsInfo;
+    } else {
+      return null;
+    }
+  } catch (e) {
+    print('Error fetching event data: $e');
+    return null;
+  }
+}

--- a/lib/pages/visitor/event_view.dart
+++ b/lib/pages/visitor/event_view.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:test/cloud_functions/pamphlets.dart';
+import 'package:test/util/navigate.dart';
+import 'package:test/pages/visitor/file_information.dart';
 
 class EventViewPage extends StatefulWidget {
   // const EventViewPage({super.key});
-  const EventViewPage({Key? key, required this.eventCode}) : super(key: key);
+  const EventViewPage({Key? key, required this.eventName, required this.startDate, required this.endDate, required this.eventCode}) : super(key: key);
+  final String eventName;
+  final String startDate;
+  final String endDate;
   final String eventCode;
-
   @override
   State<EventViewPage> createState() => _EventViewPageState();
 }
@@ -12,33 +17,127 @@ class EventViewPage extends StatefulWidget {
 class _EventViewPageState extends State<EventViewPage> {
   final TextStyle myTextStyle = const TextStyle(fontSize: 25);
 
+  List _pamphletData = [];
+
+  @override
+  void initState() {
+    super.initState();
+    loadData();
+  }
+
+  void loadData() async {
+    _pamphletData = await getAllBoothInfoForAnEvent(widget.eventCode);
+    setState(() {});
+  }
+
+  Padding getSearchBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 50),
+      child: SearchAnchor(
+        isFullScreen: false,
+        // viewLeading: const Icon(null),
+        viewLeading: IconButton(
+            onPressed: () {
+              FocusScope.of(context).requestFocus(FocusNode());
+              Navigator.pop(context);
+            },
+            icon: const Icon(Icons.arrow_back)),
+        builder: (BuildContext context, SearchController controller) {
+          return SearchBar(
+            controller: controller,
+            padding: const MaterialStatePropertyAll<EdgeInsets>(
+                EdgeInsets.symmetric(horizontal: 16.0)),
+            onTap: () {
+              controller.openView();
+            },
+            onChanged: (_) {
+              controller.openView();
+            },
+            leading: const Icon(Icons.search),
+          );
+        },
+        suggestionsBuilder:
+            (BuildContext context, SearchController controller) {
+          return List<ListTile>.generate(_pamphletData.length, (index) {
+            final String orgName = _pamphletData[index]['orgName'];
+            return ListTile(
+                title: Text(orgName),
+                onTap: () {
+                  FocusScope.of(context).unfocus();
+                  setState(() {
+                    controller.closeView(orgName);
+                  });
+                });
+          });
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         leading: const BackButton(),
-        title: Text(widget.eventCode),
+        title: Text(widget.eventName),
       ),
       body: Center(
         child: Column(
           children: [
             Text(
-              "Booth Number (Organization)",
+              "Start Date: ${widget.startDate}",
               style: myTextStyle,
             ),
             Text(
-              "Name: example name",
+              "End Date: ${widget.endDate}",
               style: myTextStyle,
             ),
-            Text("Contact: example@gmail.com", style: myTextStyle),
-            Text(
-              "Phone number: (+81) 000-0000-0000",
-              style: myTextStyle,
+            // getAllBoothInfoForAnEvent(widget.eventCode)
+            getSearchBar(context),
+            const SizedBox(
+              height: 20,
             ),
-            Text(
-              "PDF",
-              style: myTextStyle,
-            ),
+            Expanded(
+              // flex: 100,
+              child: Scrollbar(
+                thickness: 15,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: _pamphletData.length,
+                  itemBuilder: (context, index) {
+                    final String boothNumber = _pamphletData[index]['boothNumber'];
+                    final String orgName = _pamphletData[index]['orgName'];
+
+                    final String yourName = _pamphletData[index]['yourName'];
+                    final String emailAddress = _pamphletData[index]['emailAddress'];
+                    final String phoneNumber = _pamphletData[index]['phoneNumber'];
+
+                    final String boothCode = _pamphletData[index]['boothCode'];
+                    return Container(
+                      margin: const EdgeInsets.symmetric(
+                          vertical: 5, horizontal: 100),
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10)),
+                        ),
+                        // TODO: query event by event code
+                        onPressed: () => moveToPage(context, FileInformationPage(
+                            orgName: orgName,
+                            boothNumber: boothNumber,
+                            yourName: yourName, 
+                            emailAddress: emailAddress, 
+                            phoneNumber: phoneNumber, 
+                            boothCode: boothCode,
+                        )),
+                        child: ListTile(
+                          title: Text("$boothNumber ($orgName)"),
+                        ),
+                      ),
+                    );
+                  }),
+              ),
+            )
           ],
         ),
       ),

--- a/lib/pages/visitor/events.dart
+++ b/lib/pages/visitor/events.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
-
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:flutter/services.dart';
 import 'package:test/util/navigate.dart';
 import 'package:test/pages/visitor/event_view.dart';
 import 'package:test/pages/visitor/register_new_event.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:test/cloud_functions/event.dart';
+
 
 class EventsPage extends StatefulWidget {
   const EventsPage({super.key});
@@ -19,45 +15,15 @@ class EventsPage extends StatefulWidget {
 class _EventsPageState extends State<EventsPage> {
   List _eventData = [];
 
-  // Future<void> readJson() async {
-  //   final String response =
-  //       // await rootBundle.loadString('assets/dummy_event.json');
-  //       await rootBundle.loadString('assets/save_registered_event_by_visitors.json');
-  //   final data = await json.decode(response);
-  //   setState(() {
-  //     _eventData = data["events"];
-  //   });
-  //   debugPrint(_eventData.toString());
-  // }
-  Future<void> readJson() async {
-    try {
-      final directory = await getApplicationDocumentsDirectory();
-      final file = File('${directory.path}/save_registered_event_by_visitors.json');
-
-      // ファイルが存在するか確認
-      if (!await file.exists()) {
-        print("file not found");
-        return;
-      }
-
-      // ファイルからJSONを読み込む
-      String content = await file.readAsString();
-      final data = jsonDecode(content);
-
-      setState(() {
-        _eventData = data["events"] ?? [];
-      });
-
-      debugPrint(_eventData.toString());
-    } catch (e) {
-      print("error occurred: $e");
-    }
-  }
-
   @override
   void initState() {
-    readJson();
     super.initState();
+    loadData();
+  }
+
+  void loadData() async {
+    _eventData = await GetEventListFromLocalFile.readJson();
+    setState(() {});
   }
 
   Padding getSearchBar(BuildContext context) {
@@ -140,6 +106,9 @@ class _EventsPageState extends State<EventsPage> {
                   itemCount: _eventData.length,
                   itemBuilder: (context, index) {
                     final String eventName = _eventData[index]['event_name'];
+                    final String startDate = _eventData[index]['start_date'];
+                    final String endDate = _eventData[index]['end_date'];
+                    final String eventCode = _eventData[index]['event_code'];
                     return Container(
                       margin: const EdgeInsets.symmetric(
                           vertical: 5, horizontal: 100),
@@ -149,7 +118,12 @@ class _EventsPageState extends State<EventsPage> {
                               borderRadius: BorderRadius.circular(10)),
                         ),
                         // TODO: query event by event code
-                        onPressed: () => moveToPage(context, EventViewPage(eventCode: eventName)),
+                        onPressed: () => moveToPage(context, EventViewPage(
+                            eventName: eventName, 
+                            startDate: startDate, 
+                            endDate: endDate, 
+                            eventCode: eventCode,
+                        )),
                         child: ListTile(
                           title: Text(eventName),
                         ),

--- a/lib/pages/visitor/file_information.dart
+++ b/lib/pages/visitor/file_information.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:test/cloud_functions/pamphlets.dart'; // このパスは適宜修正してください。
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'dart:io';
+
+class FileInformationPage extends StatefulWidget {
+  const FileInformationPage({Key? key, required this.orgName, required this.boothNumber, required this.yourName, required this.emailAddress, required this.phoneNumber, required this.boothCode}) : super(key: key);
+  final String orgName;
+  final String boothNumber;
+  final String yourName;
+  final String emailAddress;
+  final String phoneNumber;
+  final String boothCode;
+
+  @override
+  State<FileInformationPage> createState() => _FileInformationPageState();
+}
+
+class _FileInformationPageState extends State<FileInformationPage> {
+  final TextStyle myTextStyle = const TextStyle(fontSize: 25);
+  String? localPath;
+
+  @override
+  void initState() {
+    super.initState();
+    loadData();
+  }
+
+  void loadData() async {
+    var pdfData = await getPamphletPdf(widget.boothCode);
+    if (pdfData != null && pdfData.isNotEmpty) {
+      downloadFile(pdfData["pamphletURL"]);
+    }
+  }
+
+  Future<void> downloadFile(String url) async {
+    try {
+      final ref = FirebaseStorage.instance.ref().child(url);
+      final bytes = await ref.getData();
+
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/${widget.boothCode}.pdf');
+
+      await file.writeAsBytes(bytes!, flush: true);
+
+      setState(() {
+        localPath = file.path;
+      });
+    } catch (e) {
+    print('error: $e');
+   }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: const BackButton(),
+        title: Text("${widget.boothNumber} (${widget.orgName})"),
+      ),
+      body: SingleChildScrollView( // PDF表示を含むコンテンツが縦に長くなる可能性があるため、SingleChildScrollViewを使用
+        child: Column(
+          children: [
+            Text(
+              "Name: ${widget.yourName}",
+              style: myTextStyle,
+            ),
+            Text(
+              "Contact: ${widget.emailAddress} (${widget.phoneNumber})",
+              style: myTextStyle,
+            ),
+            const SizedBox(height: 20),
+            localPath != null
+              ? Expanded(
+                  child: PDFView(
+                    filePath: localPath,
+                  ),
+                )
+              : const Center(child: CircularProgressIndicator()),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/visitor/register_new_event.dart
+++ b/lib/pages/visitor/register_new_event.dart
@@ -66,7 +66,7 @@ class _RegisterNewEventPageState extends State<RegisterNewEventPage> {
 // }
   Future<void> registerButtonPressed(BuildContext context) async {
     String eventCode = _eventCodeInputController.text;
-    var eventDetails = await getEventNameByCode(eventCode); 
+    var eventDetails = await getEventInfo(eventCode); 
     bool isEventCodeValid =
         // eventCode == "logic"; 
         eventDetails != null; //TODO: check if event code is valid
@@ -89,8 +89,9 @@ class _RegisterNewEventPageState extends State<RegisterNewEventPage> {
                           "event_name": eventName,
                           "start_date": startDate,
                           "end_date": endDate,
+                          "event_code": eventCode,
                         };
-                        saveRegisteredEvent("save_registered_event_by_visitors.json", newEvent);
+                        saveEventToLocalFile("registered_events_by_visitors.json", newEvent);
                         popToPage(context, "EventsPage");
                       },
                       child: const Text("ok"))
@@ -113,7 +114,7 @@ class _RegisterNewEventPageState extends State<RegisterNewEventPage> {
       }
     }
   }
-  Future<void> saveRegisteredEvent(String fileName, Map<String, dynamic> newEvent) async {
+  Future<void> saveEventToLocalFile(String fileName, Map<String, dynamic> newEvent) async {
     final directory = await getApplicationDocumentsDirectory();
     final file = File('${directory.path}/$fileName');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,9 @@ dependencies:
   # file_picker: ^4.0.0
   file_picker: ^6.1.1
   path_provider: ^2.1.2
+  firebase_storage: ^11.6.0
+  flutter_pdfview: ^1.3.2
+  http: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. make all functions related to events and pamphlets
2. change exhibitors' "Upload pamphlet" page
-  When exhibitor uploads a new pamphlet, "uploadPamphlet" function is called.  
- The information is stored in the "uploaded_pamphlets" collection in the Firestore database, and the PDF file is saved in the "uploaded_pdfs" collection in Firebase Storage.
3. change visitors' "Events", "Event view", "File information" pages
- When visitor register a new event, the information of event is stored "registered_events_by_visitors.json" (I changed the file name to include the eventCode because now I cannot access the previously created "save_registered_event_by_visitors.json".)
- All events listed in "registered_events_by_visitors.json" are shown in the "Events" page.
- When each event button is pressed on "Events" page, "getAllBoothInfoForAnEvent" function is called.
- All booth information for a specific event are shown on "Event view" page.
- When each booth button is pressed on "Event view" page, "getPamphletPdf" is called to get pamphlet url of the Firebase Storage, and "downloadFile" is called to show a pdf on the local device. However, a pdf is not shown on "File information" page.  (I am not sure if this method is correct for displaying a pdf! I will think about this in this weekend.)
<img width="516" alt="スクsavedリーンショット 2024-01-25 10 09 31" src="https://github.com/minsuk00/Solution-Challenge-2024/assets/108507859/a675532c-2e6c-4466-b718-c3440c5742fe">
<img width="531" alt="スクリーンショット 2024-01-25 10 10 05" src="https://github.com/minsuk00/Solution-Challenge-2024/assets/108507859/00b87838-280c-4568-a30f-1c4c7b1e5f01">
<img width="543" alt="スクリーンショット 2024-01-25 10 16 35" src="https://github.com/minsuk00/Solution-Challenge-2024/assets/108507859/7fad881b-4342-46d6-b2ae-382542506fa2">
