### PR TITLE
Logged in as username

### DIFF
--- a/lib/pages/start.dart
+++ b/lib/pages/start.dart
@@ -206,7 +206,9 @@ class StartPage extends StatelessWidget {
 
   String _buildAppBarTitle() {
     if (loginState == 'google_auth') {
-      return 'Logged in as $username (Google)';
+      // return 'Logged in as $username (Google)';
+      String displayName = googleLogin.currentUser?.displayName ?? '';
+      return 'Logged in as $displayName';
     } else if (loginState == 'guest') {
       return 'Logged in as a GUEST';
     } else {


### PR DESCRIPTION
"Logged in as (username)" in the appBar of the start page (when logged in with Google) has been implemented. 